### PR TITLE
Adding smoke test script for the kubefed operator

### DIFF
--- a/deploy/crds/operator_v1alpha1_install_cr.yaml
+++ b/deploy/crds/operator_v1alpha1_install_cr.yaml
@@ -2,4 +2,5 @@ apiVersion: operator.kubefed.io/v1alpha1
 kind: Install
 metadata:
   name: example-install
-spec: {}
+spec:
+  scope: Namespaced

--- a/scripts/create-cluster.sh
+++ b/scripts/create-cluster.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# This script handles the creation of a cluster using kind and the
+# ability to create and configure an insecure container registry.
+
+set -e
+
+source "$(dirname "${BASH_SOURCE}")/util.sh"
+CREATE_INSECURE_REGISTRY="${CREATE_INSECURE_REGISTRY:-}"
+CONFIGURE_INSECURE_REGISTRY="${CONFIGURE_INSECURE_REGISTRY:-}"
+CONTAINER_REGISTRY_HOST="${CONTAINER_REGISTRY_HOST:-172.17.0.1:5000}"
+KIND_TAG="${KIND_TAG:-}"
+kubeconfig="${HOME}/.kube/config"
+
+function create-insecure-registry() {
+  # Run insecure registry as container
+  docker run -d -p 5000:5000 --restart=always --name registry registry:2
+}
+
+
+function configure-insecure-registry-and-reload() {
+  local cmd_context="${1}" # context to run command e.g. sudo, docker exec
+  local docker_pid="${2}"
+  ${cmd_context} "$(insecure-registry-config-cmd)"
+  ${cmd_context} "$(reload-docker-daemon-cmd "${docker_pid}")"
+}
+
+
+function reload-docker-daemon-cmd() {
+  echo "kill -s SIGHUP ${1}"
+}
+
+function create-clusters() {
+  local image_arg=""
+  if [[ "${KIND_TAG}" ]]; then
+    image_arg="--image=kindest/node:${KIND_TAG}"
+  fi
+  
+  kind create cluster --name "cluster1" ${image_arg}
+  fixup-cluster
+
+  echo "Waiting for clusters to be ready"
+  check-clusters-ready
+
+  kubectl config view --flatten > ${kubeconfig}
+  unset KUBECONFIG
+}
+
+function fixup-cluster() {
+  local kubeconfig_path="$(kind get kubeconfig-path --name cluster1)"
+  export KUBECONFIG="${KUBECONFIG:-}:${kubeconfig_path}"
+
+  # Simplify context name
+  kubectl config rename-context "kubernetes-admin@cluster1" "cluster1"
+
+  local container_ip_addr=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' cluster1-control-plane)
+  # Using the container ip allows the use of port 6443 instead of the
+  # random port intended to be exposed on localhost.
+  sed -i "s/localhost.*$/${container_ip_addr}:6443/" ${kubeconfig_path}
+
+  sed -i "s/kubernetes-admin/kubernetes-cluster1-admin/" ${kubeconfig_path}
+}
+
+function check-clusters-ready() {
+  
+  util::wait-for-condition 'ok' "kubectl --context cluster1 get --raw=/healthz &> /dev/null" 120
+}
+
+echo "Creating a cluster"
+create-clusters
+
+echo "Complete"

--- a/scripts/download-binaries.sh
+++ b/scripts/download-binaries.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+#VERSION="${VERSION:-v0.1.0-rc2}"
+VERSION="${VERSION:-0.0.10}"
+
+#OS="${OS:-linux}"
+
+cd ~/tmp
+
+# wget https://github.com/kubernetes-sigs/kubefed/releases/download/${VERSION}/kubefedctl-${VERSION}-${OS}-amd64.tgz
+
+curl -LO https://github.com/kubernetes-sigs/federation-v2/releases/download/${VERSION}/kubefedctl.tgz
+
+#sudo tar -xvzf kubefedctl-${VERSION}-${OS}-amd64.tgz
+
+sudo tar xzfP kubefedctl.tgz
+
+sudo chmod u+x kubefedctl
+
+export PATH=$PATH:/usr/local/bin
+
+sudo mv kubefedctl /usr/local/bin/ 

--- a/scripts/install-kubefed.sh
+++ b/scripts/install-kubefed.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# This script will create a namespace and deploy all the crds within the same
+# namespace
+# usage ./install.sh <location> <namespace>
+
+set -e
+ 
+
+NAMESPACE=""
+LOCATION="local"
+NAMESPACE_STR=""
+
+while getopts “n:d:” opt; do
+    case $opt in
+	n) NAMESPACE=$OPTARG ;;
+	d) LOCATION=$OPTARG ;;
+    esac
+done
+
+echo "NS=$NAMESPACE"
+echo "LOC=$LOCATION"
+
+if test X"$NAMESPACE" != X; then
+    # create a namespace 
+    kubectl create ns ${NAMESPACE}
+    NAMESPACE_STR="--namespace=${NAMESPACE}"
+fi
+
+# Install crds 
+for f in ./deploy/crds/*_crd.yaml ; do     
+  kubectl apply -f "${f}" ; 
+done
+
+# Install CR
+for f in ./deploy/crds/*_cr.yaml; do
+    kubectl apply -f "${f}" $NAMESPACE_STR
+done
+
+# Check if operator-sdk is installed or not and accordinlgy execute the command.
+if test X"$LOCATION" = Xlocal; then
+    operator-sdk &> /dev/null
+    if [ $? == 0 ]; then
+	operator-sdk up local $NAMESPACE_STR &
+    else
+	echo "Operator SDK is not installed."
+	exit 1
+    fi
+else
+    #TODO: change the location in the container stanza of the operator yaml
+    for f in ./deploy/*.yaml ; do     
+	kubectl apply -f "${f}" --validate=false $NAMESPACE_STR 
+    done
+    
+    for f in ./deploy/resources/*.crd.yaml ; do     
+	kubectl apply -f "${f}" --validate=false 
+    done
+    echo "Deployed all the operator yamls for kubefed-operator in the cluster"
+fi
+
+
+

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+NAMESPACE="${NAMESPACE:-federation-test}"
+LOCATION="${LOCATION:-local}"
+VERSION="${VERSION:-0.0.10}"
+
+function setup-infrastructure () {
+
+  ./scripts/create-cluster.sh
+  
+  ./scripts/install-kubefed.sh -n ${NAMESPACE} -d ${LOCATION} &
+
+  sleep 45 
+
+  # ./scripts/download-binaries.sh
+  
+}
+
+function enable-resources () {
+
+echo "Performing join operation using kubefedctl"
+kubefedctl join cluster1 --federation-namespace=${NAMESPACE} --host-cluster-context=cluster1 --host-cluster-name=cluster1 --cluster-context=cluster1 --add-to-registry
+
+echo "Enable FederatedTypeconfigs"
+kubefedctl enable namespaces --federation-namespace=${NAMESPACE}
+
+kubefedctl enable configmaps --federation-namespace=${NAMESPACE}
+
+
+cat <<EOF | kubectl --namespace=federation-test apply -f -
+apiVersion: types.federation.k8s.io/v1alpha1
+kind: FederatedConfigMap
+metadata:
+  name: test-configmap
+  namespace: federation-test
+spec:
+  template:
+    data:
+      key: value
+  placement:
+    clusterNames:
+    - cluster1
+EOF
+
+sleep 40
+
+# check for test-configmap name
+if kubectl get configmap -n federation-test -o jsonpath="{.items[1].metadata.name}" | grep -q "test-configmap" ; then
+   echo "Configmap resource is federated successfully"
+else
+   exit 1
+fi
+
+}
+
+
+echo "==========Setting up the infrastructure for kubefed operator============="
+setup-infrastructure
+
+echo "==========Enabling resources=============="
+enable-resources
+
+echo "==========Teardown the infrastructure======"
+./scripts/teardown.sh
+
+echo "Smoke testing is successfully completed."

--- a/scripts/teardown.sh
+++ b/scripts/teardown.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+NAMESPACE="${NAMESPACE:-federation-test}"
+CONFIGMAP="${CONFIGMAP:-test-configmap}"
+CLUSTERNAME="${CLUSTERNAME:-cluster1}"
+
+kubectl delete configmap ${CONFIGMAP} -n ${NAMESPACE}
+
+kubectl delete crd --all
+
+# kill the process id for kubefed-operator process
+kill $(ps ax | grep "kubefed-operator" | awk '{print $1}'| head -n 1)
+
+kubectl delete ns ${NAMESPACE}
+
+kind delete cluster --name=${CLUSTERNAME}

--- a/scripts/util.sh
+++ b/scripts/util.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# This library holds bash utility functions.
+
+# util::wait-for-condition blocks until the provided condition becomes true
+#
+# Globals:
+#  None
+# Arguments:
+#  - 1: message indicating what conditions is being waited for (e.g. 'config to be written')
+#  - 2: a string representing an eval'able condition.  When eval'd it should not output
+#       anything to stdout or stderr.
+#  - 3: optional timeout in seconds.  If not provided, waits forever.
+# Returns:
+#  1 if the condition is not met before the timeout
+function util::wait-for-condition() {
+  local msg=$1
+  # condition should be a string that can be eval'd.
+  local condition=$2
+  local timeout=${3:-}
+
+  local start_msg="Waiting for ${msg}"
+  local error_msg="[ERROR] Timeout waiting for ${msg}"
+
+  local counter=0
+  while ! eval ${condition}; do
+    if [[ "${counter}" = "0" ]]; then
+      echo -n "${start_msg}"
+    fi
+
+    if [[ -z "${timeout}" || "${counter}" -lt "${timeout}" ]]; then
+      counter=$((counter + 1))
+      if [[ -n "${timeout}" ]]; then
+        echo -n '.'
+      fi
+      sleep 1
+    else
+      echo -e "\n${error_msg}"
+      return 1
+    fi
+  done
+
+  if [[ "${counter}" != "0" && -n "${timeout}" ]]; then
+    echo ' done'
+  fi
+}
+readonly -f util::wait-for-condition


### PR DESCRIPTION
Fixes #11 
Use `./smoke-test.sh` command for testing this script
Assumption:
- `kubefedctl` binary is already placed in the required PATH(`/usr/local/bin`)